### PR TITLE
Revert "Lock mongoid-compatibility at 0.4.0 or newer."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ### 1.3.1 (Next)
 
-* [#8](https://github.com/mongoid/mongoid-collection-snapshot/pull/8): Lock mongoid-compatibility at 0.4.0 or newer - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 1.3.0 (1/20/2017)

--- a/mongoid-collection-snapshot.gemspec
+++ b/mongoid-collection-snapshot.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Easy maintenence of collections of processed data in MongoDB with the Mongoid ODM.'
   s.add_dependency 'mongoid', '>= 3.0'
-  s.add_dependency 'mongoid-compatibility', '>= 0.4.0'
+  s.add_dependency 'mongoid-compatibility'
   s.add_dependency 'mongoid-slug'
 end


### PR DESCRIPTION
Reverts mongoid/mongoid-collection-snapshot#8

This seems to complicate things for those using older mongoid versions.