### PR TITLE
Fix #10: incorrect connection used with Mongoid 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.3.1 (Next)
 
+* [#11](https://github.com/mongoid/mongoid-collection-snapshot/pull/11): Fix: incorrect connection used with Mongoid 6 - [@dblock](https://github.com/dblock).
 * [#8](https://github.com/mongoid/mongoid-collection-snapshot/pull/8): Lock mongoid-compatibility at 0.4.0 or newer - [@dblock](https://github.com/dblock).
 * Your contribution here.
 

--- a/lib/mongoid-collection-snapshot.rb
+++ b/lib/mongoid-collection-snapshot.rb
@@ -44,7 +44,8 @@ module Mongoid
             store_in collection: collection_name
           end
           if Mongoid::Compatibility::Version.mongoid6?
-            PersistenceContext.set(klass, database: snapshot_session.database.name)
+            ctx = PersistenceContext.set(klass, {})
+            ctx.instance_variable_set(:@client, snapshot_session)
           elsif Mongoid::Compatibility::Version.mongoid5?
             klass.mongo_client = snapshot_session
           else

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -154,9 +154,7 @@ module Mongoid
 
       context '#documents' do
         it 'uses the custom session' do
-          if Mongoid::Compatibility::Version.mongoid6?
-            expect(CustomConnectionSnapshot.new.documents.database_name).to eq :snapshot_test
-          elsif Mongoid::Compatibility::Version.mongoid5?
+          if Mongoid::Compatibility::Version.mongoid5? || Mongoid::Compatibility::Version.mongoid6?
             expect(CustomConnectionSnapshot.new.documents.mongo_client).to eq CustomConnectionSnapshot.snapshot_session
           else
             expect(CustomConnectionSnapshot.new.documents.mongo_session).to eq CustomConnectionSnapshot.snapshot_session


### PR DESCRIPTION
This works because `PersistenceContext#set` [creates and returns a new instance](https://github.com/mongodb/mongoid/blob/cfd21de2b4989b8a5ddcc5cf1a4de1ad348a230d/lib/mongoid/persistence_context.rb#L179).

Fixes #10.