### PR TITLE
Migrate Danger to use danger-pr-comment workflow

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,11 @@
+name: Danger Comment
+
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,13 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  danger:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    secrets: inherit
+    with:
+      ruby-version: '3.0'
+      bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.3.3 (Next)
 
+* [#15](https://github.com/mongoid/mongoid-collection-snapshot/pull/15): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 1.3.2 (6/4/2017)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,1 +1,5 @@
-danger.import_dangerfile(gem: "mongoid-danger")
+# frozen_string_literal: true
+
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
+changelog.check!

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ else
 end
 
 group :development, :test do
-  gem 'mongoid-danger', '~> 0.1.1'
+  gem 'danger'
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
   gem 'rake'
   gem 'rspec', '~> 3.1'
   gem 'rubocop', '0.47.1'


### PR DESCRIPTION
## Summary
- Replace `mongoid-danger` with `danger`, `danger-changelog`, and `danger-pr-comment` gems
- Update Dangerfile to import `danger-pr-comment` and include `changelog.check!`
- Add GitHub workflows for Danger integration using reusable workflows from `numbata/danger-pr-comment`

This migration follows the pattern established in related projects:
- https://github.com/slack-ruby/slack-ruby-client/pull/581
- https://github.com/slack-ruby/slack-ruby-bot-server/pull/181

## Test plan
- [ ] Verify PR checks run successfully
- [ ] Verify Danger comments appear on PRs
- [ ] Verify changelog validation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)